### PR TITLE
docs: update PR template with ADR, test, and data safety checkboxes (closes #18)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,7 @@
 > Before opening this PR, review:
 > - `docs/dev_workflow.md`
 > - `docs/technical_requirements.md`
+> - `docs/data-layout.md` (data safety)
 
 ---
 
@@ -15,7 +16,7 @@ Closes #<issue-number>
 
 ## Scope check (must be true)
 - [ ] This PR addresses **one issue only**
-- [ ] Changes are limited to the issue’s defined scope
+- [ ] Changes are limited to the issue's defined scope
 - [ ] No opportunistic refactors or unrelated changes
 
 ---
@@ -23,6 +24,7 @@ Closes #<issue-number>
 ## Contract & behavior changes
 If this PR changes behavior, contracts, or invariants:
 - [ ] An ADR was added or updated (`docs/decisions/`)
+- [ ] Tests and fixtures updated for contract changes
 - [ ] ESOD updated **only if** structure/responsibilities changed
 - [ ] Technical Requirements updated **only if** constraints changed
 
@@ -30,7 +32,19 @@ If this PR changes behavior, contracts, or invariants:
 
 ---
 
+## Documentation & audit trail
+- [ ] Run-log template reviewed and updated (if relevant to this change)
+- [ ] Copilot instructions updated (if workflow changes)
+
+---
+
 ## Data safety
 - [ ] No real financial data added to the repo
 - [ ] `data/raw/` and `state/` remain git-ignored
-- [ ] Any sample data added is synthetic or reda
+- [ ] Any sample data added is synthetic and appropriate for committed test data
+- [ ] Dry-run mode used for validation (when applicable)
+
+---
+
+## Reviewer notes
+<!-- Optional: add context for reviewers, known limitations, or follow-up tasks. -->


### PR DESCRIPTION
Updates .github/pull_request_template.md with all required checkboxes:
- ADR updated if behavior/contract changed
- Tests and fixtures updated for contract changes  
- Run-log template reviewed and updated (if relevant)
- Copilot instructions updated (if workflow changes)
- No real data added to repo
- Dry-run used for validation (when applicable)

Aligns with ESOD v3 and dev_workflow discipline requirements.

Closes #18