### PR TITLE
feat: parse declared date range from filename (closes #9)

### DIFF
--- a/src/silver_garbanzo/contracts.py
+++ b/src/silver_garbanzo/contracts.py
@@ -1,0 +1,94 @@
+"""
+contracts.py — Filename and data contract validation.
+
+Implements the filename-based date range contract that is the primary
+safety mechanism for ingest operations.
+"""
+
+import re
+from datetime import datetime
+from typing import NamedTuple
+
+
+class FilenameRange(NamedTuple):
+    """Parsed filename components and declared date range."""
+    account: str
+    start_date: datetime
+    end_date: datetime
+    filename: str
+
+
+def parse_filename_range(filename: str) -> FilenameRange:
+    """
+    Parse a bank CSV filename and extract account, start date, and end date.
+    
+    Supported formats:
+    - Monthly: <account>__YYYY-MM.csv
+    - Explicit range: <account>__YYYY-MM-DD__YYYY-MM-DD.csv
+    
+    Args:
+        filename: The CSV filename (basename, not full path).
+    
+    Returns:
+        FilenameRange with account, start_date, end_date, and original filename.
+    
+    Raises:
+        ValueError: If filename does not match any supported format or
+                   contains invalid dates.
+    """
+    # Remove .csv extension if present
+    base = filename.replace('.csv', '').replace('.CSV', '')
+    
+    # Pattern 1: Monthly format <account>__YYYY-MM
+    monthly_pattern = r'^(.+?)__(\d{4})-(\d{2})$'
+    match = re.match(monthly_pattern, base)
+    if match:
+        account, year, month = match.groups()
+        try:
+            start_date = datetime(int(year), int(month), 1)
+            # End date is last day of month
+            if int(month) == 12:
+                end_date = datetime(int(year) + 1, 1, 1)
+            else:
+                end_date = datetime(int(year), int(month) + 1, 1)
+            # Subtract one day from end_date to get the last day of the month
+            from datetime import timedelta
+            end_date = end_date - timedelta(days=1)
+            
+            return FilenameRange(
+                account=account,
+                start_date=start_date,
+                end_date=end_date,
+                filename=filename
+            )
+        except ValueError as e:
+            raise ValueError(f"Invalid date in monthly filename '{filename}': {e}")
+    
+    # Pattern 2: Explicit range <account>__YYYY-MM-DD__YYYY-MM-DD
+    range_pattern = r'^(.+?)__(\d{4})-(\d{2})-(\d{2})__(\d{4})-(\d{2})-(\d{2})$'
+    match = re.match(range_pattern, base)
+    if match:
+        account, year1, month1, day1, year2, month2, day2 = match.groups()
+        try:
+            start_date = datetime(int(year1), int(month1), int(day1))
+            end_date = datetime(int(year2), int(month2), int(day2))
+            
+            # Validate that start_date <= end_date
+            if start_date > end_date:
+                raise ValueError(f"Start date {start_date} is after end date {end_date}")
+            
+            return FilenameRange(
+                account=account,
+                start_date=start_date,
+                end_date=end_date,
+                filename=filename
+            )
+        except ValueError as e:
+            raise ValueError(f"Invalid date range in filename '{filename}': {e}")
+    
+    # No pattern matched
+    raise ValueError(
+        f"Filename '{filename}' does not match supported formats. "
+        f"Expected: <account>__YYYY-MM.csv or "
+        f"<account>__YYYY-MM-DD__YYYY-MM-DD.csv"
+    )

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,156 @@
+"""
+test_contracts.py — Tests for filename and contract validation.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from silver_garbanzo.contracts import FilenameRange, parse_filename_range
+
+
+class TestParseFilenameRangeMonthly:
+    """Test parsing of monthly format: <account>__YYYY-MM.csv"""
+    
+    def test_valid_monthly_format(self):
+        """Parse valid monthly filename."""
+        result = parse_filename_range("checking__2026-01.csv")
+        assert result.account == "checking"
+        assert result.start_date == datetime(2026, 1, 1)
+        assert result.end_date == datetime(2026, 1, 31)
+        assert result.filename == "checking__2026-01.csv"
+    
+    def test_valid_monthly_format_december(self):
+        """Parse valid monthly filename for December (edge case)."""
+        result = parse_filename_range("savings__2025-12.csv")
+        assert result.account == "savings"
+        assert result.start_date == datetime(2025, 12, 1)
+        assert result.end_date == datetime(2025, 12, 31)
+    
+    def test_valid_monthly_format_february(self):
+        """Parse valid monthly filename for February (leap year edge case)."""
+        result = parse_filename_range("checking__2024-02.csv")
+        assert result.account == "checking"
+        assert result.start_date == datetime(2024, 2, 1)
+        assert result.end_date == datetime(2024, 2, 29)
+    
+    def test_valid_monthly_format_february_non_leap(self):
+        """Parse valid monthly filename for February non-leap year."""
+        result = parse_filename_range("checking__2025-02.csv")
+        assert result.account == "checking"
+        assert result.start_date == datetime(2025, 2, 1)
+        assert result.end_date == datetime(2025, 2, 28)
+    
+    def test_account_with_underscores(self):
+        """Account names can contain underscores."""
+        result = parse_filename_range("my_checking_account__2026-01.csv")
+        assert result.account == "my_checking_account"
+    
+    def test_invalid_month(self):
+        """Fail on invalid month."""
+        with pytest.raises(ValueError, match="Invalid date in monthly filename"):
+            parse_filename_range("checking__2026-13.csv")
+    
+    def test_invalid_month_zero(self):
+        """Fail on month zero."""
+        with pytest.raises(ValueError, match="Invalid date in monthly filename"):
+            parse_filename_range("checking__2026-00.csv")
+    
+    def test_missing_extension(self):
+        """Parse filename without .csv extension."""
+        result = parse_filename_range("checking__2026-01")
+        assert result.account == "checking"
+        assert result.start_date == datetime(2026, 1, 1)
+
+
+class TestParseFilenameRangeExplicit:
+    """Test parsing of explicit range format: <account>__YYYY-MM-DD__YYYY-MM-DD.csv"""
+    
+    def test_valid_explicit_range_format(self):
+        """Parse valid explicit range filename."""
+        result = parse_filename_range("checking__2026-01-15__2026-02-14.csv")
+        assert result.account == "checking"
+        assert result.start_date == datetime(2026, 1, 15)
+        assert result.end_date == datetime(2026, 2, 14)
+    
+    def test_valid_explicit_range_same_day(self):
+        """Parse explicit range with same start and end date."""
+        result = parse_filename_range("checking__2026-01-15__2026-01-15.csv")
+        assert result.account == "checking"
+        assert result.start_date == datetime(2026, 1, 15)
+        assert result.end_date == datetime(2026, 1, 15)
+    
+    def test_invalid_explicit_range_start_after_end(self):
+        """Fail when start date is after end date."""
+        with pytest.raises(ValueError, match="Start date .* is after end date"):
+            parse_filename_range("checking__2026-02-14__2026-01-15.csv")
+    
+    def test_invalid_day_in_explicit_range(self):
+        """Fail on invalid day in explicit range."""
+        with pytest.raises(ValueError, match="Invalid date range"):
+            parse_filename_range("checking__2026-02-30__2026-03-01.csv")
+    
+    def test_account_with_dashes(self):
+        """Account names can contain dashes."""
+        result = parse_filename_range("my-checking__2026-01-01__2026-01-31.csv")
+        assert result.account == "my-checking"
+
+
+class TestParseFilenameRangeInvalid:
+    """Test invalid filename formats."""
+    
+    def test_no_account(self):
+        """Fail when account is missing."""
+        with pytest.raises(ValueError, match="does not match supported formats"):
+            parse_filename_range("__2026-01.csv")
+    
+    def test_missing_separators(self):
+        """Fail on missing separators."""
+        with pytest.raises(ValueError, match="does not match supported formats"):
+            parse_filename_range("checking2026-01.csv")
+    
+    def test_wrong_format(self):
+        """Fail on completely wrong format."""
+        with pytest.raises(ValueError, match="does not match supported formats"):
+            parse_filename_range("checking.2026.01.csv")
+    
+    def test_empty_string(self):
+        """Fail on empty filename."""
+        with pytest.raises(ValueError, match="does not match supported formats"):
+            parse_filename_range("")
+    
+    def test_only_extension(self):
+        """Fail on only extension."""
+        with pytest.raises(ValueError, match="does not match supported formats"):
+            parse_filename_range(".csv")
+    
+    def test_partial_date_format(self):
+        """Fail on partial date (e.g., only year)."""
+        with pytest.raises(ValueError, match="does not match supported formats"):
+            parse_filename_range("checking__2026.csv")
+    
+    def test_too_many_double_underscores(self):
+        """Fail on too many separators."""
+        with pytest.raises(ValueError, match="does not match supported formats"):
+            parse_filename_range("checking__2026-01__2026-02__extra.csv")
+
+
+class TestParseFilenameRangeReturnType:
+    """Test return type structure."""
+    
+    def test_returns_named_tuple(self):
+        """Result is a FilenameRange named tuple."""
+        result = parse_filename_range("checking__2026-01.csv")
+        assert isinstance(result, FilenameRange)
+        assert hasattr(result, 'account')
+        assert hasattr(result, 'start_date')
+        assert hasattr(result, 'end_date')
+        assert hasattr(result, 'filename')
+    
+    def test_named_tuple_fields_are_correct_types(self):
+        """Named tuple fields have correct types."""
+        result = parse_filename_range("checking__2026-01-15__2026-02-14.csv")
+        assert isinstance(result.account, str)
+        assert isinstance(result.start_date, datetime)
+        assert isinstance(result.end_date, datetime)
+        assert isinstance(result.filename, str)


### PR DESCRIPTION
Implements filename range parsing for issue #9 (Phase B).

Supported formats:
- Monthly: account__YYYY-MM.csv → parses to (account, 1st of month, last of month)
- Explicit: account__YYYY-MM-DD__YYYY-MM-DD.csv → parses to (account, start, end)

Includes:
- Pure function parse_filename_range() in contracts.py
- FilenameRange named tuple (account, start_date, end_date, filename)
- 22 unit tests covering valid/invalid cases, edge cases (leap years, December), and error handling

Fails fast on invalid format or invalid dates.

PR Template Validation:
- [x] Addresses one issue only (#9)
- [x] Changes limited to scope (filename parsing only)
- [x] No real data added
- [x] Tests updated (22 new tests, all passing)
- [x] No ADR needed (contract already defined in ESOD)
- [x] Lint passed (ruff)

Closes #9