### PR TITLE
Atomic registry updates for ingested_ranges.csv (SRS-2.1, #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ See [docs/data-layout.md](docs/data-layout.md) for detailed conventions.
 - [x] Validate CSV header schema (Date, Description, Amount, Transaction_Type)
 - [x] Enforce filename-to-CSV date contract
 - [x] Track ingested ranges in local registry
+- [x] Atomic registry updates
 - [ ] Track & prevent overlaps
-- [ ] Atomic registry updates
 
 ### Phase C — Safety & Testing (⏳ PLANNED)
 - [ ] Dry-run mode

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -122,7 +122,7 @@ Schema:
 
 account,start_date,end_date,source_file,ingested_at
 
-Registry is appended after every successful ingest and serves as the audit trail for all ingested ranges.
+Registry is appended after every successful ingest and serves as the audit trail for all ingested ranges. Updates are performed atomically: write to a temp file, then replace the original file in a single operation to prevent partial writes.
 
 7.2 Overlap definition
 

--- a/docs/run-log.md
+++ b/docs/run-log.md
@@ -33,7 +33,7 @@ Use this template to record a manual ingestion run. Each run should be appended 
   - Split totals match original: yes/no (if no, explain)
 
 - **Post-run actions:**
-  - `state/ingested_ranges.csv` appended: yes/no (audit registry for all prior ingests)
+  - `state/ingested_ranges.csv` appended: yes/no (audit registry for all prior ingests; updates are atomic and never leave partial writes)
   - Exports written to: `state/exports/run-YYYY-MM-DD.csv`
   - PR/Issue created for manual follow-up: #[number]
 

--- a/docs/technical_requirements.md
+++ b/docs/technical_requirements.md
@@ -16,7 +16,7 @@ Mode: Batch CLI only
 Invocation: User-initiated, synchronous execution
 State:
 Persistent state limited to:
-range registry (state/ingested_ranges.csv; schema: account,start_date,end_date,source_file,ingested_at; append after every successful ingest)
+range registry (state/ingested_ranges.csv; schema: account,start_date,end_date,source_file,ingested_at; append after every successful ingest; updates performed via atomic file replace)
 No background processes
 No daemons
 No scheduled jobs

--- a/src/silver_garbanzo/contracts.py
+++ b/src/silver_garbanzo/contracts.py
@@ -137,7 +137,7 @@ def parse_filename_range(filename: str) -> FilenameRange:
 
 def append_range_registry(account: str, start_date: datetime, end_date: datetime, source_file: str, registry_path: str = None) -> None:
     """
-    Append a successfully ingested range to the registry CSV.
+    Append a successfully ingested range to the registry CSV atomically.
     Args:
         account: Account name
         start_date: Range start (datetime)
@@ -148,11 +148,24 @@ def append_range_registry(account: str, start_date: datetime, end_date: datetime
     if registry_path is None:
         registry_path = os.path.join(os.path.dirname(__file__), '..', '..', 'state', 'ingested_ranges.csv')
         registry_path = os.path.normpath(registry_path)
+    state_dir = os.path.dirname(registry_path)
+    os.makedirs(state_dir, exist_ok=True)
     ingested_at = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
     row = [account, start_date.strftime('%Y-%m-%d'), end_date.strftime('%Y-%m-%d'), source_file, ingested_at]
-    file_exists = os.path.isfile(registry_path)
-    with open(registry_path, 'a', newline='', encoding='utf-8') as f:
-        writer = csv.writer(f)
-        if not file_exists:
-            writer.writerow(['account', 'start_date', 'end_date', 'source_file', 'ingested_at'])
-        writer.writerow(row)
+    # Read existing rows
+    rows = []
+    if os.path.isfile(registry_path):
+        with open(registry_path, newline='', encoding='utf-8') as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+    if not rows:
+        rows = [['account', 'start_date', 'end_date', 'source_file', 'ingested_at']]
+    rows.append(row)
+    # Write to temp file
+    import tempfile
+    with tempfile.NamedTemporaryFile('w', delete=False, dir=state_dir, newline='', encoding='utf-8') as tf:
+        writer = csv.writer(tf)
+        writer.writerows(rows)
+        temp_path = tf.name
+    # Atomically replace registry
+    os.replace(temp_path, registry_path)

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -211,3 +211,33 @@ def test_append_range_registry(tmp_path):
     except Exception:
         import pytest
         pytest.fail("ingested_at is not ISO8601 UTC")
+
+
+def test_append_range_registry_atomic(tmp_path):
+    from silver_garbanzo.contracts import append_range_registry
+    import csv
+    import os
+    from datetime import datetime
+    account = "checking"
+    start_date = datetime(2026, 1, 1)
+    end_date = datetime(2026, 1, 31)
+    source_file = "checking__2026-01.csv"
+    registry_path = tmp_path / "ingested_ranges.csv"
+    # Write initial row
+    append_range_registry(account, start_date, end_date, source_file, str(registry_path))
+    # Write second row
+    append_range_registry("savings", start_date, end_date, "savings__2026-01.csv", str(registry_path))
+    # Check file exists and has both rows
+    assert os.path.isfile(registry_path)
+    with open(registry_path, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        rows = list(reader)
+    assert rows[0] == ["account", "start_date", "end_date", "source_file", "ingested_at"]
+    assert rows[1][:4] == [account, "2026-01-01", "2026-01-31", source_file]
+    assert rows[2][:4] == ["savings", "2026-01-01", "2026-01-31", "savings__2026-01.csv"]
+    # ingested_at is ISO8601 UTC
+    for r in rows[1:]:
+        try:
+            datetime.strptime(r[4], "%Y-%m-%dT%H:%M:%SZ")
+        except Exception:
+            pytest.fail("ingested_at is not ISO8601 UTC")


### PR DESCRIPTION
Implements atomic registry updates: writes to a temp file and replaces the original in a single operation. Ensures no partial writes, preserves all content, and creates state/ if missing. Documentation and tests updated. Closes #14.