### PR TITLE
Add --dry-run mode, CLI, docs, and tests (issue #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ See [docs/data-layout.md](docs/data-layout.md) for detailed conventions.
 - [x] Atomic registry updates
 - [x] Track & prevent overlaps (see `src/silver_garbanzo/overlap.py`)
 
-### Phase C — Safety & Testing (⏳ PLANNED)
-- [ ] Dry-run mode
+### Phase C — Safety & Testing (⏳ IN PROGRESS)
+- [x] Dry-run mode (`--dry-run` CLI flag: validates all contracts, prevents state/output writes)
 - [ ] Profile mode
 - [ ] Sample datasets & CI fixtures
 - [ ] Config validation

--- a/docs/data-layout.md
+++ b/docs/data-layout.md
@@ -190,3 +190,9 @@ A: Not recommended. Each user maintains their own ingestion history and local co
 - [.gitignore](../../.gitignore) — Data safety ignore rules
 - [docs/dev_workflow.md](../dev_workflow.md) — Data safety rules in workflow
 - [docs/esod.md](../esod.md#data-separation) — System design reference
+
+### Dry-run Mode
+
+- When running with `--dry-run`, no files in `state/` or `data/sample/` are written or modified.
+- All contract checks, validations, and warnings are performed as normal.
+- Output indicates dry-run status and what would have changed.

--- a/docs/dev_workflow.md
+++ b/docs/dev_workflow.md
@@ -51,6 +51,15 @@ Branch naming:
 
 ---
 
+## Feature Implementation Example
+
+- For features like dry-run mode, create a dedicated feature branch (e.g., `feat/13-dry-run-mode`).
+- Add CLI flags and ensure all contract checks run in dry-run mode, but no state/output files are written.
+- Add tests to verify dry-run logic (no registry writes, all validations run).
+- Update documentation to reflect new CLI options and behavior.
+
+---
+
 ## Merging to main
 
 - Merge `dev` → `main` only at phase boundaries or after a coherent set of issues

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -111,6 +111,13 @@ Dates or amounts cannot be parsed reliably
 
 There is no silent fallback.
 
+6.4 Dry-run mode
+
+- CLI flag `--dry-run` runs all contract checks, validations, and warnings
+- No registry, output, or state files are written
+- Output clearly indicates dry-run status and what would have changed
+- Used for safe validation and CI
+
 7. Overlap prevention (MVP approach)
 7.1 Range registry
 

--- a/docs/technical_requirements.md
+++ b/docs/technical_requirements.md
@@ -18,6 +18,7 @@ State:
 Persistent state limited to:
 range registry (state/ingested_ranges.csv; schema: account,start_date,end_date,source_file,ingested_at; append after every successful ingest; updates performed via atomic file replace)
 Overlap detection enforced via `src/silver_garbanzo/overlap.py` (see PRD/ESOD for details)
+Dry-run mode (`--dry-run`): all validations run, no state/output files written
 No background processes
 No daemons
 No scheduled jobs

--- a/src/silver_garbanzo/cli.py
+++ b/src/silver_garbanzo/cli.py
@@ -1,0 +1,17 @@
+import argparse
+from .ingest import ingest
+
+def main():
+    parser = argparse.ArgumentParser(description="Silver Garbanzo CLI")
+    parser.add_argument("csv_file", help="Path to CSV file to ingest")
+    parser.add_argument("--dry-run", action="store_true", help="Run all validations but do not write any state or output files")
+    # ...add other arguments as needed...
+    args = parser.parse_args()
+
+    # Indicate dry-run mode
+    if args.dry_run:
+        print("[DRY-RUN] No state or output files will be written.")
+    ingest(args.csv_file, dry_run=args.dry_run)
+
+if __name__ == "__main__":
+    main()

--- a/src/silver_garbanzo/ingest.py
+++ b/src/silver_garbanzo/ingest.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from .contracts import validate_csv_headers, validate_csv_date_range, parse_filename_range, append_range_registry
+from .overlap import check_range_overlap
+import os
+
+def ingest(csv_path, dry_run=False, registry_path=None):
+    filename = os.path.basename(csv_path)
+    range_info = parse_filename_range(filename)
+    account = range_info.account
+    start_date = range_info.start_date
+    end_date = range_info.end_date
+    # Load CSV
+    df = pd.read_csv(csv_path)
+    validate_csv_headers(list(df.columns))
+    rows = df.to_dict(orient="records")
+    validate_csv_date_range(rows, start_date, end_date)
+    # Overlap check
+    check_range_overlap(account, start_date, end_date, registry_path)
+    # Dry-run: do not write registry
+    if dry_run:
+        print(f"[DRY-RUN] Would append to registry: {account}, {start_date.date()}-{end_date.date()}, {filename}")
+        return True
+    # Write registry
+    append_range_registry(account, start_date, end_date, filename, registry_path)
+    print(f"Ingested: {filename} ({start_date.date()}-{end_date.date()})")
+    return True

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,40 @@
+import os
+import tempfile
+import pandas as pd
+import pytest
+from silver_garbanzo.ingest import ingest
+
+def make_sample_csv(path, dates):
+    df = pd.DataFrame({
+        "Date": dates,
+        "Description": ["desc"] * len(dates),
+        "Amount": ["1.0"] * len(dates),
+        "Transaction_Type": ["DEBIT"] * len(dates)
+    })
+    df.to_csv(path, index=False)
+
+def test_dry_run_does_not_write_registry(tmp_path):
+    csv_path = tmp_path / "checking__2026-01.csv"
+    registry_path = tmp_path / "ingested_ranges.csv"
+    make_sample_csv(csv_path, ["2026-01-01", "2026-01-15", "2026-01-31"])
+    # Create empty registry
+    with open(registry_path, "w", encoding="utf-8") as f:
+        f.write("account,start_date,end_date,source_file,ingested_at\n")
+    ingest(str(csv_path), dry_run=True, registry_path=str(registry_path))
+    # Registry should be unchanged
+    with open(registry_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    assert len(lines) == 1  # Only header
+
+def test_normal_ingest_writes_registry(tmp_path):
+    csv_path = tmp_path / "checking__2026-01.csv"
+    registry_path = tmp_path / "ingested_ranges.csv"
+    make_sample_csv(csv_path, ["2026-01-01", "2026-01-15", "2026-01-31"])
+    with open(registry_path, "w", encoding="utf-8") as f:
+        f.write("account,start_date,end_date,source_file,ingested_at\n")
+    ingest(str(csv_path), dry_run=False, registry_path=str(registry_path))
+    # Registry should have header + 1 row
+    with open(registry_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    assert len(lines) == 2
+    assert "checking__2026-01.csv" in lines[1]


### PR DESCRIPTION
Implements --dry-run mode for safe contract validation, updates documentation, adds CLI entry point and ingest logic, and tests. Closes #13.